### PR TITLE
Docker image generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:alpine3.18 AS builder
+RUN mkdir /app
+WORKDIR /app
+COPY . .
+RUN go build -o ganache-cli-block-explorer .
+
+FROM alpine:3.18 AS final
+RUN mkdir /app
+WORKDIR /app
+COPY --from=builder /app/ganache-cli-block-explorer .
+COPY --from=builder /app/static ./static
+COPY --from=builder /app/template ./template
+RUN chmod +x ./ganache-cli-block-explorer
+EXPOSE 5051
+ENTRYPOINT [ "./ganache-cli-block-explorer", "--bind", "0.0.0.0" ]
+
+# docker build -t ganache-cli-block-explorer .ª
+# docker run -d --publish 5051:5051 ganache-cli-block-explorer

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ Note : This web application hosts in port `5051`, please make sure the port `505
 ```sh
 Enter the ganache host and port in the welcome page Eg: http://127.0.0.1:8545, Good to Go.. Enjoy !
 ```
+
+### Docker
+To run Ganache-CLI-Block-Explorer in docker follow this steps:
+1. Build an image `docker build -t ganache-cli-block-explorer .`
+2. Launch the image exposing the port `docker run -d --publish 5051:5051 ganache-cli-block-explorer`
+	- Note that docker can't access the local machine port (you can still access other ip or docker internal ip)
+
+
 ### Development
 
 Want to contribute? Great!

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ To run Ganache-CLI-Block-Explorer in docker follow this steps:
 2. Launch the image exposing the port `docker run -d --publish 5051:5051 ganache-cli-block-explorer`
 	- Note that docker can't access the local machine port (you can still access other ip or docker internal ip)
 
+Check out also the example for docker compose in docker-examples/docker-compose.yml
+
 
 ### Development
 

--- a/docker-example/docker-compose.yml
+++ b/docker-example/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3'
+
+services:
+    # Ganache CLI instance
+    ganache:
+        image: "trufflesuite/ganache-cli:v6.12.2"
+        # SPecify the db folder
+        command: --db /ganache
+        # This will be the service name in the network
+        container_name: ganache
+        restart: unless-stopped
+        ports:
+            - "8545:8545"
+        # Save ganache db to a persistent storage
+        volumes:
+          - ganache:/ganache
+    # Block explorer instance
+    block-explorer:
+      # Build this image as specified in Readme
+      # To access ganache instance use url http://ganache:8545
+      image: "ganache-cli-block-explorer" 
+      ports:
+        - "5051:5051"
+
+volumes:
+    ganache:

--- a/router.go
+++ b/router.go
@@ -605,7 +605,7 @@ func main() {
 
 	fmt.Println("!!!!INITIALIZING SERVER!!!!")
 
-	// Evaluate launch flags. Syntax is (flag, default value, help message)
+	// Evaluate launch flags. Syntax is (flag, default value, help message). This allows for go run router.go ... --bind 0.0.0.0
 	// Web interface 
 	bindAddress := flag.String("bind","127.0.0.1", "Bind the web interface to the specified address. Defaults to 127.0.0.1")
 	bindPort := flag.String("port", "5051", "Bind the web interface to the specified port. Defaults to 5051")

--- a/router.go
+++ b/router.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"strconv"
 	"time"
+	"flag"
 )
 
 // *********************** variable ********************************************
@@ -603,6 +604,15 @@ func welcomePage(w http.ResponseWriter, r *http.Request) {
 func main() {
 
 	fmt.Println("!!!!INITIALIZING SERVER!!!!")
+
+	// Evaluate launch flags. Syntax is (flag, default value, help message)
+	// Web interface 
+	bindAddress := flag.String("bind","127.0.0.1", "Bind the web interface to the specified address. Defaults to 127.0.0.1")
+	bindPort := flag.String("port", "5051", "Bind the web interface to the specified port. Defaults to 5051")
+	flag.Parse()
+	// Final URL for Web UI
+	bindURL := *bindAddress + ":" + *bindPort
+
 	// mux router
 	gorilla := mux.NewRouter()
 
@@ -627,11 +637,11 @@ func main() {
 	// Note: Here gorilla is like passing our own server handler into net/http, by default its false
 	srv := &http.Server{
 		Handler: gorilla,
-		Addr:    "127.0.0.1:5051",
+		Addr:    bindURL,
 		// Good practice: enforce timeouts for servers you create!
 		WriteTimeout: 15 * time.Second,
 		ReadTimeout:  15 * time.Second,
 	}
-	fmt.Println("!!!! SERVER STARTED at ADDRESS : 127.0.0.1:5051 !!!!")
+	fmt.Println("!!!! SERVER STARTED at ADDRESS : " + bindURL + " !!!!")
 	log.Fatal(srv.ListenAndServe())
 }


### PR DESCRIPTION
Prepared everything to be able to generate docker image.

- Added support for `--bind x.x.x.x` and `--port 1234` flags on launch
- Prepared Dockerfile for docker image generation
- Added details on dokcer image in Readme
- Prepared example for docker compose

I temporarily uploaded the generated image to Docker Hub ([https://hub.docker.com/repository/docker/aleben/ganache-cli-block-explorer](https://hub.docker.com/repository/docker/aleben/ganache-cli-block-explorer)) but I would be happy to take it down if you upload a version in your name (If you want you can also generate the repo in Docker hub and give me access, I'll push it myself under your name).